### PR TITLE
Changing the map Style

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -13,7 +13,8 @@ export default class extends Controller {
 
     this.map = new mapboxgl.Map({
       container: this.element,
-      style: "mapbox://styles/mapbox/standard"
+      // style: "mapbox://styles/mapbox/standard"
+      style:"mapbox://styles/acetonemapbox/cm7x93w99016u01sb6a5q9c5u"
     })
     this.#addMarkersToMap()
     this.#fitMapToMarkers()


### PR DESCRIPTION

- Génération d'un nouveau style de map développé sur Mapbox studio: Modification du fichier "map_controller.js" pour:
	- Suppression du style: "mapbox://styles/mapbox/standard"
     	- Ajout du nouveau style:"mapbox://styles/acetonemapbox/cm7x93w99016u01sb6a5q9c5u"
     	
Note: compte Mapbox d'Antoine et utilisation de son Access token
